### PR TITLE
Fix Access Controls 

### DIFF
--- a/ICSerializer/Classes/ICSerializable.swift
+++ b/ICSerializer/Classes/ICSerializable.swift
@@ -27,7 +27,7 @@ import ObjectiveC
     // e.g. [ "originalKeyName" : "destinationKeyName" ]
     
     /// Properties that will have its name transformed to avoid conflicts
-    public var serializationKeyTransforms: [String : String]? = ["_description" : "description"]
+    open var serializationKeyTransforms: [String : String]? = ["_description" : "description"]
     
     required public override init() {
         super.init()

--- a/ICSerializer/Classes/ICSystemKeys.swift
+++ b/ICSerializer/Classes/ICSystemKeys.swift
@@ -32,7 +32,7 @@ public class ICSystemKeys: NSObject {
         return ""
     }
     
-    static func isSystemKey(_ key: String) -> Bool {
+    public static func isSystemKey(_ key: String) -> Bool {
         if key.isEmpty {
             return true
         }


### PR DESCRIPTION
I've updated access control for a property and a static function. The rule of Swift on open and public access controls:

> An `open` class is accessible and subclass-able outside of the defining module. An open class member is accessible and overridable outside of the defining module.

> A `public` class is accessible but not subclass-able outside of the defining module. A public class member is accessible but not overridable outside of the defining module.