### PR TITLE
Exclude non-JSON data from serializer 

### DIFF
--- a/Example/Tests/ISerializable+Deserialize.swift
+++ b/Example/Tests/ISerializable+Deserialize.swift
@@ -7,12 +7,14 @@
 //
 
 import XCTest
+import ICSerializer
+
 @testable import ICSerializerDemo
 
 class ISerializable_Deserialize: XCTestCase {
     
     func test1_should_Serialize_Deserialize() {
-
+        
         let issue = Issue()
         issue.assignees = [Assignee]()
         
@@ -22,11 +24,48 @@ class ISerializable_Deserialize: XCTestCase {
             issue.assignees?.append(assignee)
         }
         issue.assignee = issue.assignees?.first
-
+        
         let serializedIssue = issue.serializeToDictionary()
         
         let deserializedIssue = Issue.deserialize(serializedIssue)
         XCTAssertTrue(issue.isEqual(deserializedIssue))
     }
     
+    func test2_shouldExcludeUIKitObjects() {
+        //given
+        let myProfile = Profile(name: "Ajith R Nayak", profilePhoto: UIImage(), favrtColor: UIColor.red)
+        // when
+        let serializedIssue = myProfile.serializeToDictionary()
+        let name = serializedIssue["name"]
+        let profilePhoto = serializedIssue["profilePhoto"]
+        let favrtColor = serializedIssue["favrtColor"]
+        //then
+        XCTAssertEqual(serializedIssue.count, 1)
+        XCTAssertNotNil(name)
+        XCTAssertNil(profilePhoto)
+        XCTAssertNil(favrtColor)
+    }
+}
+
+extension ISerializable_Deserialize {
+    
+    class Profile: ICSerializable {
+        var name: String?
+        var profilePhoto: UIImage?
+        var favrtColor: UIColor?
+        
+        init(name: String, profilePhoto: UIImage,
+             favrtColor: UIColor) {
+            self.name = name
+            self.profilePhoto = profilePhoto
+            self.favrtColor = favrtColor
+        }
+        
+        required init() {
+            super.init()
+            self.name = nil
+            self.profilePhoto = nil
+            self.favrtColor = nil
+        }
+    }
 }

--- a/ICSerializer/Classes/ICSerializable.swift
+++ b/ICSerializer/Classes/ICSerializable.swift
@@ -54,22 +54,35 @@ import ObjectiveC
             }
             
             // We only serialize properties that have a value, props that are nil will be ignored
-            if let objectValue: AnyObject = originalValue as AnyObject? {
-                if let array = objectValue as? [ICSerializable], option == .deep {
-                    var _array = [AnyObject]()
-                    for e in array {
-                        let dict = e.serializeToDictionary()
-                        _array.append(dict as AnyObject)
-                    }
-                    dictionary[jsonKey] = _array as AnyObject?
-                } else if let obj = objectValue as? ICSerializable {
-                    let dict = obj.serializeToDictionary()
-                    dictionary[jsonKey] = dict as AnyObject?
-                } else if let date = objectValue as? Date {
-                    dictionary[jsonKey] = date.description as AnyObject?
-                } else {
-                    dictionary[jsonKey] = objectValue
+            guard let objectValue: AnyObject = originalValue as AnyObject? else {
+                continue
+            }
+            
+            if objectValue is UIImage {
+                continue
+            }
+            
+            if objectValue is UIColor {
+                continue
+            }
+            
+            if let array = objectValue as? [ICSerializable], option == .deep {
+                var _array = [AnyObject]()
+                for e in array {
+                    let dict = e.serializeToDictionary()
+                    _array.append(dict as AnyObject)
                 }
+                dictionary[jsonKey] = _array as AnyObject?
+            }
+            else if let obj = objectValue as? ICSerializable {
+                let dict = obj.serializeToDictionary()
+                dictionary[jsonKey] = dict as AnyObject?
+            }
+            else if let date = objectValue as? Date {
+                dictionary[jsonKey] = date.description as AnyObject?
+            }
+            else {
+                dictionary[jsonKey] = objectValue
             }
         }
         return dictionary


### PR DESCRIPTION
UIKit objects such as UIImage and UIColor are skipped during serialisation. 